### PR TITLE
在engine下使用rails generate的时候会报Setting未定义的错

### DIFF
--- a/lib/homeland/site/engine.rb
+++ b/lib/homeland/site/engine.rb
@@ -3,7 +3,7 @@ module Homeland::Site
     isolate_namespace Homeland::Site
 
     initializer 'homeland.site.init' do |app|
-      next unless Setting.has_module?(:site)
+      next unless (defined? Setting) && Setting.has_module?(:site)
       Homeland.register_plugin do |plugin|
         plugin.name = Homeland::Site::NAME
         plugin.display_name = '酷站'


### PR DESCRIPTION
在engine下使用rails generate的时候会报错：uninitialized constant Homeland::Site::Engine::Setting